### PR TITLE
DB強化資材内で指定したDB名の存在チェックをする

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ module "terraform-aws-modify-db-schedule" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.13.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.50.0 |
 
 ## Modules
 
@@ -63,6 +63,7 @@ No modules.
 | [aws_cloudwatch_event_rule.modify-db](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.modify-db](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_sfn_state_machine.modify_db_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sfn_state_machine) | resource |
+| [aws_db_instance.check_existence_db](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/db_instance) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,11 @@
  * ```
  */
 
+# DB存在確認の為の記述
+data "aws_db_instance" "check_existence_db" {
+  db_instance_identifier = var.modify_parameters.DbInstanceIdentifier
+}
+
 resource "aws_cloudwatch_event_rule" "modify-db" {
   name                = "${var.resource_prefix}-${local.encode_cron}"
   schedule_expression = var.schedule_expression


### PR DESCRIPTION
概要：
RDSが存在しない場合に異常終了する挙動を実装した。
* dataリソースを読み込みにて指定したリソースが存在しない場合にterraform planエラーとなる挙動を利用した


証跡：
リソースが存在する場合：
　terraform planが正常に実行される

リソースが存在しない場合：
　terraform planがエラーとなる
